### PR TITLE
feat: Backup data dumps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.1.0-beta1",
       "license": "MIT",
       "dependencies": {
+        "aws-sdk": "^2.1022.0",
         "commander": "^8.2.0",
         "datocms-client": "^3.4.18",
         "dotenv": "^10.0.0",
@@ -1565,6 +1566,61 @@
         "node": ">= 4.5.0"
       }
     },
+    "node_modules/aws-sdk": {
+      "version": "2.1022.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1022.0.tgz",
+      "integrity": "sha512-JIXk8xhBztPKe4hrBHaJ9zyjWrHUhuQhRex18BSJERwryifgMcxLjb/LFJrcYWP0d49g/WrV/GpYkpc23MBV/Q==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/aws-sdk/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "node_modules/aws-sdk/node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2084,7 +2140,6 @@
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -5615,6 +5670,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7167,7 +7230,6 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "peer": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -7535,6 +7597,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -9670,6 +9737,23 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -10997,6 +11081,53 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "peer": true
     },
+    "aws-sdk": {
+      "version": "2.1022.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1022.0.tgz",
+      "integrity": "sha512-JIXk8xhBztPKe4hrBHaJ9zyjWrHUhuQhRex18BSJERwryifgMcxLjb/LFJrcYWP0d49g/WrV/GpYkpc23MBV/Q==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -11409,7 +11540,6 @@
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "peer": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -14214,6 +14344,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -15470,8 +15605,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "peer": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -15774,6 +15908,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "saxes": {
       "version": "5.0.1",
@@ -17491,6 +17630,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1022.0",
-        "axios": "^0.24.0",
         "commander": "^8.2.0",
         "datocms-client": "^3.4.18",
         "dotenv": "^10.0.0",
+        "got": "^11.8.2",
         "inquirer": "^8.2.0",
         "luxon": "^2.0.2"
       },
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
-      "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
+      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
       "engines": {
         "node": ">=10"
       },
@@ -1635,14 +1635,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
-    "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.3.1.tgz",
@@ -2218,15 +2210,11 @@
       }
     },
     "node_modules/cacheable-lookup": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
-      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
-      "dependencies": {
-        "@types/keyv": "^3.1.1",
-        "keyv": "^4.0.0"
-      },
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=10.6.0"
       }
     },
     "node_modules/cacheable-request": {
@@ -2937,12 +2925,96 @@
         "dato": "bin/dato.js"
       }
     },
+    "node_modules/datocms-client/node_modules/@sindresorhus/is": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+      "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/datocms-client/node_modules/cacheable-lookup": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+      "dependencies": {
+        "@types/keyv": "^3.1.1",
+        "keyv": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/datocms-client/node_modules/decompress-response": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/datocms-client/node_modules/dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
       "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/datocms-client/node_modules/got": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+      "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+      "dependencies": {
+        "@sindresorhus/is": "^2.0.0",
+        "@szmarczak/http-timer": "^4.0.0",
+        "@types/cacheable-request": "^6.0.1",
+        "cacheable-lookup": "^2.0.0",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^5.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^5.0.0",
+        "lowercase-keys": "^2.0.0",
+        "mimic-response": "^2.1.0",
+        "p-cancelable": "^2.0.0",
+        "p-event": "^4.0.0",
+        "responselike": "^2.0.0",
+        "to-readable-stream": "^2.0.0",
+        "type-fest": "^0.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/datocms-client/node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/datocms-client/node_modules/type-fest": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+      "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/datocms-contentful-to-structured-text": {
@@ -2994,14 +3066,17 @@
       }
     },
     "node_modules/decompress-response": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
-      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dependencies": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^3.1.0"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dedent": {
@@ -4244,42 +4319,27 @@
       }
     },
     "node_modules/got": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
-      "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
       "dependencies": {
-        "@sindresorhus/is": "^2.0.0",
-        "@szmarczak/http-timer": "^4.0.0",
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
-        "cacheable-lookup": "^2.0.0",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
         "cacheable-request": "^7.0.1",
-        "decompress-response": "^5.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^5.0.0",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
-        "mimic-response": "^2.1.0",
         "p-cancelable": "^2.0.0",
-        "p-event": "^4.0.0",
-        "responselike": "^2.0.0",
-        "to-readable-stream": "^2.0.0",
-        "type-fest": "^0.10.0"
+        "responselike": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=10.19.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/got/node_modules/type-fest": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-      "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {
@@ -4537,6 +4597,18 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-browserify": {
@@ -6270,11 +6342,11 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7252,6 +7324,17 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7473,6 +7556,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -10490,9 +10578,9 @@
       }
     },
     "@sindresorhus/is": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
-      "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
+      "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -11147,14 +11235,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
-    "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "requires": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
     "babel-jest": {
       "version": "27.3.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.3.1.tgz",
@@ -11622,13 +11702,9 @@
       }
     },
     "cacheable-lookup": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
-      "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
-      "requires": {
-        "@types/keyv": "^3.1.1",
-        "keyv": "^4.0.0"
-      }
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
     },
     "cacheable-request": {
       "version": "7.0.2",
@@ -12221,10 +12297,64 @@
         "wpapi": "^1.2.2"
       },
       "dependencies": {
+        "@sindresorhus/is": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+          "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg=="
+        },
+        "cacheable-lookup": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+          "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+          "requires": {
+            "@types/keyv": "^3.1.1",
+            "keyv": "^4.0.0"
+          }
+        },
+        "decompress-response": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+          "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
         "dotenv": {
           "version": "8.6.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
           "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="
+        },
+        "got": {
+          "version": "10.7.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+          "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+          "requires": {
+            "@sindresorhus/is": "^2.0.0",
+            "@szmarczak/http-timer": "^4.0.0",
+            "@types/cacheable-request": "^6.0.1",
+            "cacheable-lookup": "^2.0.0",
+            "cacheable-request": "^7.0.1",
+            "decompress-response": "^5.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^5.0.0",
+            "lowercase-keys": "^2.0.0",
+            "mimic-response": "^2.1.0",
+            "p-cancelable": "^2.0.0",
+            "p-event": "^4.0.0",
+            "responselike": "^2.0.0",
+            "to-readable-stream": "^2.0.0",
+            "type-fest": "^0.10.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+        },
+        "type-fest": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+          "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw=="
         }
       }
     },
@@ -12266,11 +12396,11 @@
       "peer": true
     },
     "decompress-response": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
-      "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "requires": {
-        "mimic-response": "^2.0.0"
+        "mimic-response": "^3.1.0"
       }
     },
     "dedent": {
@@ -13265,32 +13395,21 @@
       "dev": true
     },
     "got": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
-      "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
       "requires": {
-        "@sindresorhus/is": "^2.0.0",
-        "@szmarczak/http-timer": "^4.0.0",
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
-        "cacheable-lookup": "^2.0.0",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
         "cacheable-request": "^7.0.1",
-        "decompress-response": "^5.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^5.0.0",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
-        "mimic-response": "^2.1.0",
         "p-cancelable": "^2.0.0",
-        "p-event": "^4.0.0",
-        "responselike": "^2.0.0",
-        "to-readable-stream": "^2.0.0",
-        "type-fest": "^0.10.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-          "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw=="
-        }
+        "responselike": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -13485,6 +13604,15 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
       }
     },
     "https-browserify": {
@@ -14842,9 +14970,9 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -15632,6 +15760,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "peer": true
     },
+    "quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -15819,6 +15952,11 @@
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
+    },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "resolve-cwd": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1022.0",
+        "axios": "^0.24.0",
         "commander": "^8.2.0",
         "datocms-client": "^3.4.18",
         "dotenv": "^10.0.0",
@@ -1635,11 +1636,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/babel-jest": {
@@ -2606,6 +2607,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/contentful-management/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/contentful-sdk-core": {
@@ -11139,11 +11148,11 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "babel-jest": {
@@ -11922,6 +11931,16 @@
         "fast-copy": "^2.1.0",
         "lodash.isplainobject": "^4.0.6",
         "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        }
       }
     },
     "contentful-sdk-core": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/craftzing/datocms-backup#readme",
   "dependencies": {
     "aws-sdk": "^2.1022.0",
+    "axios": "^0.24.0",
     "commander": "^8.2.0",
     "datocms-client": "^3.4.18",
     "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/craftzing/datocms-backup#readme",
   "dependencies": {
+    "aws-sdk": "^2.1022.0",
     "commander": "^8.2.0",
     "datocms-client": "^3.4.18",
     "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "homepage": "https://github.com/craftzing/datocms-backup#readme",
   "dependencies": {
     "aws-sdk": "^2.1022.0",
-    "axios": "^0.24.0",
     "commander": "^8.2.0",
     "datocms-client": "^3.4.18",
     "dotenv": "^10.0.0",
+    "got": "^11.8.2",
     "inquirer": "^8.2.0",
     "luxon": "^2.0.2"
   },

--- a/src/aws.fake.ts
+++ b/src/aws.fake.ts
@@ -1,0 +1,5 @@
+export const S3 = {
+    upload: jest.fn(() => ({
+        promise: () => {},
+    })),
+};

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,7 +2,7 @@ import { Output } from './output';
 
 export type Command = {
     readonly name: string
-    readonly arguments?: ArgumentDefinition[]
+    readonly args?: ArgumentDefinition[]
     readonly options?: OptionDefinition[]
     readonly handle: Handler
     readonly subCommands?: Command[]

--- a/src/command.ts
+++ b/src/command.ts
@@ -23,11 +23,12 @@ export type OptionDefinition = {
     readonly flag: string
     readonly shortFlag?: string
     readonly description: string
+    readonly choices?: string[]
     readonly defaultValue?: string | boolean
 }
 
 export type Options = {
-    [name: string]: boolean
+    [name: string]: boolean | string
     debug: boolean
 }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -4,8 +4,8 @@ export type Command = {
     readonly name: string
     readonly args?: ArgumentDefinition[]
     readonly options?: OptionDefinition[]
-    readonly handle: Handler
     readonly subCommands?: Command[]
+    handle(args: Arguments, options: Options, output: Output): Promise<void>
 }
 
 export type ArgumentDefinition = {
@@ -31,5 +31,3 @@ export type Options = {
     [name: string]: boolean | string
     debug: boolean
 }
-
-export type Handler = (args: Arguments, options: Options, output: Output) => Promise<void>;

--- a/src/commands/cleanup.spec.ts
+++ b/src/commands/cleanup.spec.ts
@@ -1,29 +1,21 @@
 import { output } from '../output.fake';
 import { Command } from '../command';
-import { COMMAND } from './cleanup';
+import * as Cleanup from './cleanup';
 import * as OlderThan from './cleanup/olderThan';
 
 describe('command', () => {
     it('should have a descriptive name', () => {
-        expect(COMMAND.name).toEqual('cleanup');
-    });
-
-    it('should not have arguments', () => {
-        expect(COMMAND.arguments).toEqual(undefined);
-    });
-
-    it('should not have options', () => {
-        expect(COMMAND.options).toEqual(undefined);
+        expect(Cleanup.name).toEqual('cleanup');
     });
 
     it('should have subcommands', () => {
-        expect(COMMAND.subCommands).toEqual<Command[]>([
-            OlderThan.COMMAND,
+        expect(Cleanup.subCommands).toEqual<Command[]>([
+            OlderThan,
         ]);
     });
 
     it('should output help by default', async () => {
-        await COMMAND.handle({}, { debug: false }, output);
+        await Cleanup.handle({}, { debug: false }, output);
 
         expect(output.help).toHaveBeenCalledTimes(1);
     });

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -2,12 +2,12 @@ import { Arguments, Command, Options } from '../command';
 import { Output } from '../output';
 import * as OlderThan from './cleanup/olderThan';
 
-export const COMMAND: Command = {
-    name: 'cleanup',
-    async handle(args: Arguments, options: Options, output: Output): Promise<void> {
-        output.help();
-    },
-    subCommands: [
-        OlderThan.COMMAND,
-    ],
+export const name: string = 'cleanup';
+
+export async function handle(args: Arguments, options: Options, output: Output): Promise<void> {
+    output.help();
 }
+
+export const subCommands: Command[] = [
+    OlderThan,
+];

--- a/src/commands/cleanup/olderThan.spec.ts
+++ b/src/commands/cleanup/olderThan.spec.ts
@@ -3,17 +3,22 @@ import { expectOutputToBeCanceled, expectOutputToBeCompleted } from '../../../.j
 import { FailedToStartCleanup, MisconfigurationError } from '../../errors/misconfigurationErrors';
 import { CleanupFailed, RuntimeError } from '../../errors/runtimeErrors';
 import { fakeConfirmation, output } from '../../output.fake';
-import { client, fakeBackup, fakeErrorWhileGettingBackups } from '../../dato.fake';
+import * as DatoFake from '../../dato.fake';
 import { BackupEnvironment } from '../../dato';
 import { ArgumentDefinition, OptionDefinition } from '../../command';
 import * as Command from './olderThan';
 
 jest.mock('../../dato', () => ({
     ...jest.requireActual<object>('../../dato'),
-    createClient: jest.fn(() => client),
+    createClient: jest.fn(() => DatoFake.client),
 }));
 
 describe('command', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        DatoFake.reset();
+    });
+
     it('should have a descriptive name', () => {
         expect(Command.name).toEqual('older-than');
     });
@@ -62,7 +67,7 @@ describe('command', () => {
     });
 
     it('should exit with an error when it failed to retrieve all existing backups', async () => {
-        fakeErrorWhileGettingBackups();
+        DatoFake.throwErrorWhileGettingBackups();
 
         try {
             await Command.handle(
@@ -83,12 +88,12 @@ describe('command', () => {
             output,
         );
 
-        expect(client.deleteEnvironmentById).not.toHaveBeenCalled();
+        expect(DatoFake.client.deleteEnvironmentById).not.toHaveBeenCalled();
         expectOutputToBeCompleted(output);
     });
 
     it('can handle cleanup when there are no backups older than the retention date', async () => {
-        fakeBackup(DateTime.local().minus({ weeks: 1 }).toISO());
+        DatoFake.backup(DateTime.local().minus({ weeks: 1 }).toISO());
 
         await Command.handle(
             { age: '2w' },
@@ -96,12 +101,12 @@ describe('command', () => {
             output,
         );
 
-        expect(client.deleteEnvironmentById).not.toHaveBeenCalled();
+        expect(DatoFake.client.deleteEnvironmentById).not.toHaveBeenCalled();
         expectOutputToBeCompleted(output);
     });
 
     it('does not cleanup backups when confirmation is rejected', async () => {
-        fakeBackup(DateTime.local().minus({ days: 3 }).toISO());
+        DatoFake.backup(DateTime.local().minus({ days: 3 }).toISO());
 
         await Command.handle(
             { age: '2d' },
@@ -109,7 +114,7 @@ describe('command', () => {
             output,
         );
 
-        expect(client.deleteEnvironmentById).not.toHaveBeenCalled();
+        expect(DatoFake.client.deleteEnvironmentById).not.toHaveBeenCalled();
         expectOutputToBeCanceled(output);
         expect(output.confirm).toHaveBeenCalledTimes(1);
         expect(output.confirm).toHaveBeenCalledWith(
@@ -118,8 +123,8 @@ describe('command', () => {
     });
 
     it('can cleanup backups older than the specified age when confirmed', async () => {
-        const backupToDelete = fakeBackup(DateTime.local().minus({ months: 2 }).toISO());
-        const backupToKeep = fakeBackup(DateTime.local().minus({ months: 1 }).toISO());
+        const backupToDelete = DatoFake.backup(DateTime.local().minus({ months: 2 }).toISO());
+        const backupToKeep = DatoFake.backup(DateTime.local().minus({ months: 1 }).toISO());
         fakeConfirmation();
 
         await Command.handle(
@@ -135,9 +140,9 @@ describe('command', () => {
 });
 
 async function expectBackupNotToBeDeleted(backup: BackupEnvironment): Promise<void> {
-    expect(client.deleteEnvironmentById).not.toHaveBeenCalledWith(backup.id);
+    expect(DatoFake.client.deleteEnvironmentById).not.toHaveBeenCalledWith(backup.id);
 }
 
 async function expectBackupToBeDeleted(backup: BackupEnvironment): Promise<void> {
-    expect(client.deleteEnvironmentById).toHaveBeenCalledWith(backup.id);
+    expect(DatoFake.client.deleteEnvironmentById).toHaveBeenCalledWith(backup.id);
 }

--- a/src/commands/cleanup/olderThan.spec.ts
+++ b/src/commands/cleanup/olderThan.spec.ts
@@ -72,7 +72,7 @@ describe('command', () => {
             );
         } catch (error) {
             expect(error).toBeInstanceOf(RuntimeError);
-            expect(error).toEqual(CleanupFailed.datoApiReturnedWithAnErrorWhileGettingBackupEnvironments());
+            expect(error).toBeInstanceOf(CleanupFailed);
         }
     });
 

--- a/src/commands/cleanup/olderThan.spec.ts
+++ b/src/commands/cleanup/olderThan.spec.ts
@@ -6,7 +6,7 @@ import { fakeConfirmation, output } from '../../output.fake';
 import { client, fakeBackup, fakeErrorWhileGettingBackups } from '../../dato.fake';
 import { BackupEnvironment } from '../../dato';
 import { ArgumentDefinition, OptionDefinition } from '../../command';
-import { COMMAND } from './olderThan';
+import * as Command from './olderThan';
 
 jest.mock('../../dato', () => ({
     ...jest.requireActual<object>('../../dato'),
@@ -15,11 +15,11 @@ jest.mock('../../dato', () => ({
 
 describe('command', () => {
     it('should have a descriptive name', () => {
-        expect(COMMAND.name).toEqual('older-than');
+        expect(Command.name).toEqual('older-than');
     });
 
     it('should have arguments', () => {
-        expect(COMMAND.arguments).toEqual<ArgumentDefinition[]>([
+        expect(Command.args).toEqual<ArgumentDefinition[]>([
             {
                 name: 'age',
                 description: expect.any(String),
@@ -28,7 +28,7 @@ describe('command', () => {
     });
 
     it('should have options', () => {
-        expect(COMMAND.options).toEqual<OptionDefinition[]>([
+        expect(Command.options).toEqual<OptionDefinition[]>([
             {
                 flag: 'debug',
                 shortFlag: 'd',
@@ -42,10 +42,6 @@ describe('command', () => {
         ]);
     });
 
-    it('should not have subcommands', () => {
-        expect(COMMAND.subCommands).toEqual(undefined);
-    });
-
     const invalidAges = [
         ['nonsense'],
         ['1ymd'],
@@ -54,7 +50,7 @@ describe('command', () => {
 
     it.each(invalidAges)('should throw a misconfig error when the provided age is invalid', async (age: string) => {
         try {
-            await COMMAND.handle(
+            await Command.handle(
                 { age },
                 { debug: false },
                 output,
@@ -69,7 +65,7 @@ describe('command', () => {
         fakeErrorWhileGettingBackups();
 
         try {
-            await COMMAND.handle(
+            await Command.handle(
                 { age: '1d' },
                 { debug: false },
                 output,
@@ -81,7 +77,7 @@ describe('command', () => {
     });
 
     it('can handle cleanup when there are no backups', async () => {
-        await COMMAND.handle(
+        await Command.handle(
             { age: '1w' },
             { debug: false },
             output,
@@ -94,7 +90,7 @@ describe('command', () => {
     it('can handle cleanup when there are no backups older than the retention date', async () => {
         fakeBackup(DateTime.local().minus({ weeks: 1 }).toISO());
 
-        await COMMAND.handle(
+        await Command.handle(
             { age: '2w' },
             { debug: false },
             output,
@@ -107,7 +103,7 @@ describe('command', () => {
     it('does not cleanup backups when confirmation is rejected', async () => {
         fakeBackup(DateTime.local().minus({ days: 3 }).toISO());
 
-        await COMMAND.handle(
+        await Command.handle(
             { age: '2d' },
             { debug: false },
             output,
@@ -126,7 +122,7 @@ describe('command', () => {
         const backupToKeep = fakeBackup(DateTime.local().minus({ months: 1 }).toISO());
         fakeConfirmation();
 
-        await COMMAND.handle(
+        await Command.handle(
             { age: '1m' },
             { debug: false },
             output,

--- a/src/commands/cleanup/olderThan.ts
+++ b/src/commands/cleanup/olderThan.ts
@@ -37,9 +37,7 @@ export async function handle(args: OlderThanArguments, options: Options, output:
 
         output.debug('Existing backups:', backups);
     } catch (error) {
-        output.debug(error);
-
-        throw CleanupFailed.datoApiReturnedWithAnErrorWhileGettingBackupEnvironments();
+        throw CleanupFailed.datoApiReturnedWithAnErrorWhileGettingBackupEnvironments(error);
     }
 
     const backupsOlderThanRetentionDate = backups.filter((backup: BackupEnvironment): boolean => {
@@ -95,9 +93,7 @@ export async function handle(args: OlderThanArguments, options: Options, output:
 
             output.debug('Deleted backup:', response);
         } catch (error) {
-            output.debug(error);
-
-            throw CleanupFailed.datoApiReturnedWithAnErrorWhileDeletingBackup(backup);
+            throw CleanupFailed.datoApiReturnedWithAnErrorWhileDeletingBackup(backup, error);
         }
     }
 }

--- a/src/commands/cleanup/olderThan.ts
+++ b/src/commands/cleanup/olderThan.ts
@@ -1,31 +1,30 @@
 import { DateTime, Duration } from 'luxon';
-import { Arguments, Command, Options } from '../../command';
+import { ArgumentDefinition, Arguments, Command, OptionDefinition, Options } from '../../command';
 import { Output } from '../../output';
 import { createClient, BackupEnvironment } from '../../dato';
 import { DEBUG, CONFIRM } from '../../common/options';
 import { FailedToStartCleanup } from '../../errors/misconfigurationErrors';
 import { CleanupFailed } from '../../errors/runtimeErrors';
 
-export const COMMAND: Command = {
-    name: 'older-than',
-    arguments: [
-        {
-            name: 'age',
-            description: 'An ISO8601 duration string. E.g. "5d", "1w", "P1YT6H", ...',
-        },
-    ],
-    options: [
-        DEBUG,
-        CONFIRM,
-    ],
-    handle,
-}
+export const name: string = 'older-than';
+
+export const args: ArgumentDefinition[] = [
+    {
+        name: 'age',
+        description: 'An ISO8601 duration string. E.g. "5d", "1w", "P1YT6H", ...',
+    },
+];
+
+export const options: OptionDefinition[] = [
+    DEBUG,
+    CONFIRM,
+];
 
 type OlderThanArguments = Arguments & {
     age: string
 }
 
-async function handle(args: OlderThanArguments, options: Options, output: Output): Promise<void> {
+export async function handle(args: OlderThanArguments, options: Options, output: Output): Promise<void> {
     const client = createClient();
     const retentionDate = retentionDateFromUnitArgument();
     const format = DateTime.DATETIME_MED_WITH_SECONDS;

--- a/src/commands/create.spec.ts
+++ b/src/commands/create.spec.ts
@@ -1,21 +1,14 @@
 import { freezeNow } from '../../.jest/utils/dateTime';
 import { ArgumentDefinition, OptionDefinition } from '../command';
 import { output } from '../output.fake';
-import {
-    client,
-    fakeBackup,
-    fakeErrorWhileCreatingBackup,
-    fakeErrorWhileResolvingPrimaryId,
-    fakePrimaryEnvironment,
-    fakeSandboxEnvironment,
-} from '../dato.fake';
+import * as DatoFake from '../dato.fake';
 import { BackupEnvironmentId } from '../dato';
 import { BackupFailed, RuntimeError } from '../errors/runtimeErrors';
 import * as Command from './create';
 
 jest.mock('../dato', () => ({
     ...jest.requireActual<object>('../dato'),
-    createClient: jest.fn(() => client),
+    createClient: jest.fn(() => DatoFake.client),
 }));
 
 function resolveExpectedBackupId(): BackupEnvironmentId {
@@ -28,6 +21,11 @@ describe('command', () => {
     const defaultOptions: Command.CreateOptions = {
         debug: false,
     };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        DatoFake.reset();
+    });
 
     it('should have a descriptive name', () => {
         expect(Command.name).toEqual('create');
@@ -54,7 +52,7 @@ describe('command', () => {
     });
 
     it('should exit with an error when it failed to resolve the primary environment', async () => {
-        fakeErrorWhileResolvingPrimaryId();
+        DatoFake.throwErrorWhileResolvingPrimaryId();
 
         try {
             await Command.handle(
@@ -69,9 +67,9 @@ describe('command', () => {
     });
 
     it('can create backups for the primary environment', async () => {
-        const primary = fakePrimaryEnvironment();
-        fakeBackup();
-        fakeSandboxEnvironment();
+        const primary = DatoFake.primaryEnvironment();
+        DatoFake.backup();
+        DatoFake.sandboxEnvironment();
         const expectedBackupId = resolveExpectedBackupId();
 
         await Command.handle(
@@ -80,8 +78,8 @@ describe('command', () => {
             output,
         );
 
-        expect(client.forkEnvironment).toHaveBeenCalledTimes(1);
-        expect(client.forkEnvironment).toHaveBeenCalledWith(primary.id, expectedBackupId);
+        expect(DatoFake.client.forkEnvironment).toHaveBeenCalledTimes(1);
+        expect(DatoFake.client.forkEnvironment).toHaveBeenCalledWith(primary.id, expectedBackupId);
         expect(output.completed).toHaveBeenCalledTimes(1);
         expect(output.completed).toHaveBeenCalledWith(
             expect.stringContaining(expectedBackupId),
@@ -89,9 +87,8 @@ describe('command', () => {
     });
 
     it('should exit with an error when it failed to create a backup', async () => {
-        const env = fakePrimaryEnvironment();
-        fakeErrorWhileCreatingBackup();
-        const expectedBackupId = resolveExpectedBackupId();
+        const env = DatoFake.primaryEnvironment();
+        DatoFake.throwErrorWhileCreatingBackup();
 
         try {
             await Command.handle(
@@ -106,8 +103,8 @@ describe('command', () => {
     });
 
     it('can create backups for any existing environment', async () => {
-        fakePrimaryEnvironment();
-        const env = fakeSandboxEnvironment();
+        DatoFake.primaryEnvironment();
+        const env = DatoFake.sandboxEnvironment();
         const expectedBackupId = resolveExpectedBackupId();
 
         await Command.handle(
@@ -117,8 +114,8 @@ describe('command', () => {
         );
 
         expect(output.debug).toHaveBeenCalled();
-        expect(client.forkEnvironment).toHaveBeenCalledTimes(1);
-        expect(client.forkEnvironment).toHaveBeenCalledWith(env.id, expectedBackupId);
+        expect(DatoFake.client.forkEnvironment).toHaveBeenCalledTimes(1);
+        expect(DatoFake.client.forkEnvironment).toHaveBeenCalledWith(env.id, expectedBackupId);
         expect(output.completed).toHaveBeenCalledTimes(1);
         expect(output.completed).toHaveBeenCalledWith(
             expect.stringContaining(expectedBackupId),

--- a/src/commands/create.spec.ts
+++ b/src/commands/create.spec.ts
@@ -9,9 +9,9 @@ import {
     fakeErrorWhileResolvingPrimaryId,
     fakeErrorWhileCreatingBackup,
 } from '../dato.fake';
-import { COMMAND } from './create';
 import { BackupEnvironmentId } from '../dato';
 import { BackupFailed, RuntimeError } from '../errors/runtimeErrors';
+import * as Command from './create';
 
 jest.mock('../dato', () => ({
     ...jest.requireActual<object>('../dato'),
@@ -26,11 +26,11 @@ function resolveExpectedBackupId(): BackupEnvironmentId {
 
 describe('command', () => {
     it('should have a descriptive name', () => {
-        expect(COMMAND.name).toEqual('create');
+        expect(Command.name).toEqual('create');
     });
 
     it('should have arguments', () => {
-        expect(COMMAND.arguments).toEqual<ArgumentDefinition[]>([
+        expect(Command.args).toEqual<ArgumentDefinition[]>([
             {
                 name: 'environmentId',
                 description: expect.any(String),
@@ -40,7 +40,7 @@ describe('command', () => {
     });
 
     it('should have options', () => {
-        expect(COMMAND.options).toEqual<OptionDefinition[]>([
+        expect(Command.options).toEqual<OptionDefinition[]>([
             {
                 flag: 'debug',
                 shortFlag: 'd',
@@ -49,15 +49,11 @@ describe('command', () => {
         ]);
     });
 
-    it('should not have subcommands', () => {
-        expect(COMMAND.subCommands).toEqual(undefined);
-    });
-
     it('should exit with an error when it failed to resolve the primary environment', async () => {
         fakeErrorWhileResolvingPrimaryId();
 
         try {
-            await COMMAND.handle(
+            await Command.handle(
                 { environmentId: 'primary' },
                 { debug: false },
                 output,
@@ -74,7 +70,7 @@ describe('command', () => {
         fakeSandboxEnvironment();
         const expectedBackupId = resolveExpectedBackupId();
 
-        await COMMAND.handle(
+        await Command.handle(
             { environmentId: 'primary' },
             { debug: false },
             output,
@@ -94,7 +90,7 @@ describe('command', () => {
         const expectedBackupId = resolveExpectedBackupId();
 
         try {
-            await COMMAND.handle(
+            await Command.handle(
                 { environmentId: env.id },
                 { debug: false },
                 output,
@@ -110,7 +106,7 @@ describe('command', () => {
         const env = fakeSandboxEnvironment();
         const expectedBackupId = resolveExpectedBackupId();
 
-        await COMMAND.handle(
+        await Command.handle(
             { environmentId: env.id },
             { debug: false },
             output,

--- a/src/commands/create.spec.ts
+++ b/src/commands/create.spec.ts
@@ -3,11 +3,11 @@ import { ArgumentDefinition, OptionDefinition } from '../command';
 import { output } from '../output.fake';
 import {
     client,
-    fakePrimaryEnvironment,
     fakeBackup,
-    fakeSandboxEnvironment,
-    fakeErrorWhileResolvingPrimaryId,
     fakeErrorWhileCreatingBackup,
+    fakeErrorWhileResolvingPrimaryId,
+    fakePrimaryEnvironment,
+    fakeSandboxEnvironment,
 } from '../dato.fake';
 import { BackupEnvironmentId } from '../dato';
 import { BackupFailed, RuntimeError } from '../errors/runtimeErrors';
@@ -25,6 +25,10 @@ function resolveExpectedBackupId(): BackupEnvironmentId {
 }
 
 describe('command', () => {
+    const defaultOptions: Command.CreateOptions = {
+        debug: false,
+    };
+
     it('should have a descriptive name', () => {
         expect(Command.name).toEqual('create');
     });
@@ -55,12 +59,12 @@ describe('command', () => {
         try {
             await Command.handle(
                 { environmentId: 'primary' },
-                { debug: false },
+                defaultOptions,
                 output,
             );
         } catch (error) {
             expect(error).toBeInstanceOf(RuntimeError);
-            expect(error).toEqual(BackupFailed.datoApiRespondedWithAnErrorWhileResolvingPrimaryEnvironment())
+            expect(error).toBeInstanceOf(BackupFailed);
         }
     });
 
@@ -72,7 +76,7 @@ describe('command', () => {
 
         await Command.handle(
             { environmentId: 'primary' },
-            { debug: false },
+            defaultOptions,
             output,
         );
 
@@ -92,12 +96,12 @@ describe('command', () => {
         try {
             await Command.handle(
                 { environmentId: env.id },
-                { debug: false },
+                defaultOptions,
                 output,
             );
         } catch (error) {
             expect(error).toBeInstanceOf(RuntimeError);
-            expect(error).toEqual(BackupFailed.datoApiRespondedWithAnErrorWhileCreatingBackup(expectedBackupId));
+            expect(error).toBeInstanceOf(BackupFailed);
         }
     });
 
@@ -108,7 +112,7 @@ describe('command', () => {
 
         await Command.handle(
             { environmentId: env.id },
-            { debug: false },
+            defaultOptions,
             output,
         );
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,26 +1,25 @@
 import { DateTime } from 'luxon';
 import { Output } from '../output';
-import { createClient, BackupEnvironmentId, Dato } from '../dato';
-import { Command, Arguments, Options } from '../command';
+import { createClient, BackupEnvironmentId } from '../dato';
+import { Arguments, Options, OptionDefinition, ArgumentDefinition} from '../command';
 import { DEBUG } from '../common/options';
 import { BackupFailed } from '../errors/runtimeErrors';
 
 const PRIMARY_ENV_ALIAS = 'primary';
 
-export const COMMAND: Command = {
-    name: 'create',
-    arguments: [
-        {
-            name: 'environmentId',
-            description: 'ID of the environment you want to backup',
-            defaultValue: PRIMARY_ENV_ALIAS,
-        },
-    ],
-    options: [
-        DEBUG,
-    ],
-    handle,
-}
+export const name: string = 'create';
+
+export const args: ArgumentDefinition[] = [
+    {
+        name: 'environmentId',
+        description: 'ID of the environment you want to backup',
+        defaultValue: PRIMARY_ENV_ALIAS,
+    },
+];
+
+export const options: OptionDefinition[] = [
+    DEBUG,
+]
 
 type CreateArguments = Arguments & {
     environmentId: string
@@ -30,48 +29,48 @@ type CreateOptions = Options & {
     debug: boolean
 }
 
-async function handle(args: CreateArguments, options: CreateOptions, output: Output): Promise<void> {
+export async function handle(args: CreateArguments, options: CreateOptions, output: Output): Promise<void> {
     const client = createClient();
-    const environmentIdToBackup = await resolveEnvironmentId(output, client, args.environmentId);
-    const backupId = await createBackupForEnvironment(output, client, environmentIdToBackup);
+    const environmentIdToBackup = await resolveEnvironmentId();
+    const backupId = await createBackupForEnvironment();
 
     output.completed(`Backup "${backupId}" completed.`);
-}
 
-async function resolveEnvironmentId(output: Output, client: Dato, environmentId: string): Promise<string> {
-    if (environmentId !== PRIMARY_ENV_ALIAS) {
-        return environmentId;
+    async function resolveEnvironmentId(): Promise<string> {
+        if (args.environmentId !== PRIMARY_ENV_ALIAS) {
+            return args.environmentId;
+        }
+
+        output.line('Resolving primary environment...', '🔎');
+
+        try {
+            const primaryEnvironmentId = await client.primaryEnvironmentId();
+
+            output.debug(`Found "${primaryEnvironmentId}"`);
+
+            return primaryEnvironmentId;
+        } catch (exception) {
+            output.debug(exception);
+
+            throw BackupFailed.datoApiRespondedWithAnErrorWhileResolvingPrimaryEnvironment();
+        }
     }
 
-    output.line('Resolving primary environment...', '🔎');
+    async function createBackupForEnvironment(): Promise<string> {
+        const backupId: BackupEnvironmentId = `backup-${DateTime.local().toFormat('yyyy-LL-dd')}`;
 
-    try {
-        const primaryEnvironmentId = await client.primaryEnvironmentId();
+        output.line(`Creating backup for "${environmentIdToBackup}" environment...`, '⏳');
 
-        output.debug(`Found "${primaryEnvironmentId}"`);
+        try {
+            const backup = await client.forkEnvironment(environmentIdToBackup, backupId);
 
-        return primaryEnvironmentId;
-    } catch (exception) {
-        output.debug(exception);
+            output.debug(backup);
+        } catch (exception) {
+            output.debug(exception);
 
-        throw BackupFailed.datoApiRespondedWithAnErrorWhileResolvingPrimaryEnvironment();
+            throw BackupFailed.datoApiRespondedWithAnErrorWhileCreatingBackup(backupId);
+        }
+
+        return backupId;
     }
-}
-
-async function createBackupForEnvironment(output: Output, client: Dato, environmentId: string): Promise<string> {
-    const backupId: BackupEnvironmentId = `backup-${DateTime.local().toFormat('yyyy-LL-dd')}`;
-
-    output.line(`Creating backup for "${environmentId}" environment...`, '⏳');
-
-    try {
-        const backup = await client.forkEnvironment(environmentId, backupId);
-
-        output.debug(backup);
-    } catch (exception) {
-        output.debug(exception);
-
-        throw BackupFailed.datoApiRespondedWithAnErrorWhileCreatingBackup(backupId);
-    }
-
-    return backupId;
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -7,11 +7,6 @@ import { BackupFailed } from '../errors/runtimeErrors';
 
 const PRIMARY_ENV_ALIAS = 'primary';
 
-export enum Destination {
-    Dato = 'dato',
-    S3 = 's3',
-}
-
 export const name: string = 'create';
 
 export const args: ArgumentDefinition[] = [
@@ -24,12 +19,6 @@ export const args: ArgumentDefinition[] = [
 
 export const options: OptionDefinition[] = [
     DEBUG,
-    {
-        flag: 'destination',
-        description: 'Destination for the backup',
-        choices: Object.values(Destination),
-        defaultValue: Destination.Dato,
-    },
 ];
 
 export type CreateArguments = Arguments & {
@@ -38,7 +27,6 @@ export type CreateArguments = Arguments & {
 
 export type CreateOptions = Options & {
     debug: boolean
-    destination: Destination
 }
 
 export async function handle(args: CreateArguments, options: CreateOptions, output: Output): Promise<void> {
@@ -48,10 +36,13 @@ export async function handle(args: CreateArguments, options: CreateOptions, outp
 
     output.line(`Creating backup for "${environmentIdToBackup}" environment on ${options.destination}...`, '⏳');
 
-    await {
-        [Destination.Dato]: createBackupOnDato,
-        [Destination.S3]: createBackupOnS3,
-    }[options.destination]();
+    try {
+        const backup = await client.forkEnvironment(environmentIdToBackup, backupId);
+
+        output.debug(backup);
+    } catch (error) {
+        throw BackupFailed.datoApiRespondedWithAnErrorWhileCreatingBackup(backupId, error);
+    }
 
     output.completed(`Backup "${backupId}" completed.`);
 
@@ -68,26 +59,8 @@ export async function handle(args: CreateArguments, options: CreateOptions, outp
             output.debug(`Found "${primaryEnvironmentId}"`);
 
             return primaryEnvironmentId;
-        } catch (exception) {
-            output.debug(exception);
-
-            throw BackupFailed.datoApiRespondedWithAnErrorWhileResolvingPrimaryEnvironment();
+        } catch (error) {
+            throw BackupFailed.datoApiRespondedWithAnErrorWhileResolvingPrimaryEnvironment(error);
         }
-    }
-
-    async function createBackupOnDato(): Promise<void> {
-        try {
-            const backup = await client.forkEnvironment(environmentIdToBackup, backupId);
-
-            output.debug(backup);
-        } catch (exception) {
-            output.debug(exception);
-
-            throw BackupFailed.datoApiRespondedWithAnErrorWhileCreatingBackup(backupId);
-        }
-    }
-
-    async function createBackupOnS3(): Promise<void> {
-
     }
 }

--- a/src/commands/dump.spec.ts
+++ b/src/commands/dump.spec.ts
@@ -3,7 +3,7 @@ import { ArgumentDefinition, OptionDefinition, Options } from '../command';
 import { BackupEnvironmentId } from '../dato';
 import { Driver } from '../storage';
 import { storage, errors as storageErrors, fakeErrorWhileUploadingToStorage } from '../storage.fake';
-import { client, errors as datoErrors, dataDump, fakeErrorWhileGettingDataDump } from '../dato.fake';
+import * as DatoFake from '../dato.fake';
 import { output } from '../output.fake';
 import { DumpFailed } from '../errors/runtimeErrors';
 import * as Command from './dump';
@@ -12,7 +12,7 @@ let storageDriver: string = undefined;
 
 jest.mock('../dato', () => ({
     ...jest.requireActual<object>('../dato'),
-    createClient: jest.fn(() => client),
+    createClient: jest.fn(() => DatoFake.client),
 }));
 
 jest.mock('../storage', () => ({
@@ -38,6 +38,11 @@ describe('command', () => {
     const defaultOptions: Options = {
         debug: false,
     };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        DatoFake.reset();
+    });
 
     it('should have a descriptive name', () => {
         expect(Command.name).toEqual('dump');
@@ -70,13 +75,13 @@ describe('command', () => {
     });
 
     it('fails when it could not fetch data from DatoCMS', async () => {
-        fakeErrorWhileGettingDataDump();
+        DatoFake.throwErrorWhileGettingDataDump();
 
         try {
             await Command.handle(args, defaultOptions, output);
         } catch (error) {
             expect(error).toBeInstanceOf(DumpFailed);
-            expect(error.originalError).toEqual(datoErrors.dataDump);
+            expect(error.originalError).toEqual(DatoFake.errors.dataDump);
         }
     });
 
@@ -99,6 +104,6 @@ describe('command', () => {
 
         expect(storageDriver).toEqual(args.storage);
         expect(storage.upload).toHaveBeenCalledTimes(1);
-        expect(storage.upload).toHaveBeenCalledWith(expectedPath, dataDump);
+        expect(storage.upload).toHaveBeenCalledWith(expectedPath, DatoFake.dataDump);
     });
 });

--- a/src/commands/dump.spec.ts
+++ b/src/commands/dump.spec.ts
@@ -1,0 +1,104 @@
+import { freezeNow } from '../../.jest/utils/dateTime';
+import { ArgumentDefinition, OptionDefinition, Options } from '../command';
+import { BackupEnvironmentId } from '../dato';
+import { Driver } from '../storage';
+import { storage, errors as storageErrors, fakeErrorWhileUploadingToStorage } from '../storage.fake';
+import { client, errors as datoErrors, dataDump, fakeErrorWhileGettingDataDump } from '../dato.fake';
+import { output } from '../output.fake';
+import { DumpFailed } from '../errors/runtimeErrors';
+import * as Command from './dump';
+
+let storageDriver: string = undefined;
+
+jest.mock('../dato', () => ({
+    ...jest.requireActual<object>('../dato'),
+    createClient: jest.fn(() => client),
+}));
+
+jest.mock('../storage', () => ({
+    ...jest.requireActual<object>('../storage'),
+    createStorage: jest.fn((driver: string) => {
+        storageDriver = driver;
+
+        return storage;
+    }),
+}));
+
+function resolveExpectedBackupId(): BackupEnvironmentId {
+    const now = freezeNow().toFormat('yyyy-LL-dd');
+
+    return `backup-${now}`;
+}
+
+describe('command', () => {
+    const args: Command.DumpArguments = {
+        storage: Driver.S3,
+        path: 'some/path',
+    };
+    const defaultOptions: Options = {
+        debug: false,
+    };
+
+    it('should have a descriptive name', () => {
+        expect(Command.name).toEqual('dump');
+    });
+
+    it('should have arguments', () => {
+        expect(Command.args).toEqual<ArgumentDefinition[]>([
+            {
+                name: 'storage',
+                description: expect.any(String),
+                choices: [
+                    Driver.S3,
+                ],
+            },
+            {
+                name: 'path',
+                description: expect.any(String),
+            },
+        ]);
+    });
+
+    it('should have options', () => {
+        expect(Command.options).toEqual<OptionDefinition[]>([
+            {
+                flag: 'debug',
+                shortFlag: 'd',
+                description: expect.any(String),
+            },
+        ]);
+    });
+
+    it('fails when it could not fetch data from DatoCMS', async () => {
+        fakeErrorWhileGettingDataDump();
+
+        try {
+            await Command.handle(args, defaultOptions, output);
+        } catch (error) {
+            expect(error).toBeInstanceOf(DumpFailed);
+            expect(error.originalError).toEqual(datoErrors.dataDump);
+        }
+    });
+
+    it('fails when it could not upload the data dump to storage', async () => {
+        fakeErrorWhileUploadingToStorage();
+
+        try {
+            await Command.handle(args, defaultOptions, output);
+        } catch (error) {
+            expect(error).toBeInstanceOf(DumpFailed);
+            expect(error.originalError).toEqual(storageErrors.upload);
+        }
+    });
+
+    it('can upload a data dump to storage', async () => {
+        const expectedBackupId = resolveExpectedBackupId();
+        const expectedPath = `${args.path}/${expectedBackupId}/data.json`;
+
+        await Command.handle(args, defaultOptions, output);
+
+        expect(storageDriver).toEqual(args.storage);
+        expect(storage.upload).toHaveBeenCalledTimes(1);
+        expect(storage.upload).toHaveBeenCalledWith(expectedPath, dataDump);
+    });
+});

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -1,0 +1,59 @@
+import { DateTime } from 'luxon';
+import { ArgumentDefinition, Arguments, OptionDefinition, Options } from '../command';
+import { Output } from '../output';
+import { DEBUG } from '../common/options';
+import { createClient, Dato, BackupEnvironmentId } from '../dato';
+import { createStorage, Driver, Storage } from '../storage';
+import { DumpFailed } from '../errors/runtimeErrors';
+
+export const name: string = 'dump';
+
+export const args: ArgumentDefinition[] = [
+    {
+        name: 'storage',
+        description: 'Storage service to use for the data dump',
+        choices: Object.values(Driver),
+    },
+    {
+        name: 'path',
+        description: 'The path you want to upload the data dump to in the storage service',
+    },
+];
+
+export const options: OptionDefinition[] = [
+    DEBUG,
+];
+
+export type DumpArguments = Arguments & {
+    storage: Driver
+    path: string
+}
+
+export async function handle(args: DumpArguments, options: Options, output: Output): Promise<void> {
+    const dato: Dato = createClient();
+    const storage: Storage = createStorage(args.storage);
+    const backupId: BackupEnvironmentId = `backup-${DateTime.local().toFormat('yyyy-LL-dd')}`;
+    const path = `${args.path}/`.replace('//', '/') + backupId;
+
+    output.line(`Creating dump "${path}" on "${args.storage}"...`, '⏳');
+
+    const dataDump: string = await getDataDump();
+
+    try {
+        await storage.upload(`${path}/data.json`, dataDump);
+    } catch (error) {
+        throw DumpFailed.s3ApiRespondedWithAnErrorWhileUploadingData(error);
+    }
+
+    output.completed(`Dump "${path}" on "${args.storage}" completed.`);
+
+    async function getDataDump(): Promise<string> {
+        output.line('Fetching all data from DatoCMS...', '🔎');
+
+        try {
+            return await dato.dataDump();
+        } catch (error) {
+            throw DumpFailed.datoApiRespondedWithAnErrorWhileGettingDataDump(error);
+        }
+    }
+}

--- a/src/dato.fake.ts
+++ b/src/dato.fake.ts
@@ -1,26 +1,26 @@
 import * as faker from 'faker';
 import { DateTime } from 'luxon';
-import {Dato, BackupEnvironment, BackupEnvironmentId, Environment, isBackupEnvironment} from './dato';
-
-beforeEach(() => {
-    jest.clearAllMocks();
-    reset();
-});
+import { Dato, BackupEnvironment, BackupEnvironmentId, Environment, isBackupEnvironment } from './dato';
 
 const PRIMARY_ENV_ID = 'main';
 let environments: Environment[] = [];
-let errors: {
+
+export let errors: {
     [name: string]: Error | undefined
 } = {};
 
-function reset(): void {
+export const dataDump: string = 'All DatoCMS data...';
+
+beforeEach(() => {
+    jest.clearAllMocks();
     environments = [];
     errors = {
         primaryEnvironmentId: undefined,
         backups: undefined,
         forkEnvironment: undefined,
+        dataDump: undefined,
     };
-}
+});
 
 export function fakeErrorWhileResolvingPrimaryId(): void {
     errors.primaryEnvironmentId = new Error('Faked missing primary environment.');
@@ -32,6 +32,10 @@ export function fakeErrorWhileGettingBackups(): void {
 
 export function fakeErrorWhileCreatingBackup(): void {
     errors.forkEnvironment = new Error('Faked an error while creating a backup.');
+}
+
+export function fakeErrorWhileGettingDataDump(): void {
+    errors.dataDump = new Error('Faked an error while creating a backup dump.');
 }
 
 function fakeEnvironments(...envs: Environment[]): void {
@@ -141,5 +145,13 @@ export const client: Dato = {
 
     deleteEnvironmentById: jest.fn(async (environmentId: BackupEnvironmentId): Promise<BackupEnvironment> => {
         return await siteClient.environments.destroy(environmentId);
+    }),
+
+    dataDump: jest.fn(async (): Promise<string> => {
+        if (errors.dataDump) {
+            throw errors.dataDump;
+        }
+
+        return Promise.resolve(dataDump);
     }),
 };

--- a/src/dato.fake.ts
+++ b/src/dato.fake.ts
@@ -4,6 +4,7 @@ import { Dato, BackupEnvironment, BackupEnvironmentId, Environment, isBackupEnvi
 
 const PRIMARY_ENV_ID = 'main';
 let environments: Environment[] = [];
+let assetURIs: string[] = [];
 
 export let errors: {
     [name: string]: Error | undefined
@@ -11,6 +12,7 @@ export let errors: {
 
 export function reset(): void {
     environments = [];
+    assetURIs = [];
     errors = {
         primaryEnvironmentId: undefined,
         backups: undefined,
@@ -82,6 +84,10 @@ export function sandboxEnvironment(id?: string): Environment {
     fakeEnvironments(env);
 
     return env;
+}
+
+export function willReturnAssetURIs(...assetURI: string[]): void {
+    assetURIs = assetURIs.concat(assetURI);
 }
 
 const datoItems = {
@@ -174,6 +180,6 @@ export const client: Dato = {
     }),
 
     assetURIs: jest.fn(async (): Promise<Array<string>> => {
-        return [];
+        return assetURIs;
     }),
 };

--- a/src/dato.spec.ts
+++ b/src/dato.spec.ts
@@ -3,20 +3,19 @@ import { CannotCreateDatoClient } from './errors/misconfigurationErrors';
 import { createClient, Dato, Environment } from './dato';
 import { siteClient, fakePrimaryEnvironment, fakeBackup, fakeSandboxEnvironment } from './dato.fake';
 
-const DATOCMS_BACKUP_API_TOKEN = 'some-fake-api-token';
-
 jest.mock('datocms-client', () => ({
-    ...jest.requireActual<object>('datocms-client'),
     SiteClient: jest.fn(() => siteClient),
 }));
 
-beforeEach(() => {
-    process.env = {
-        DATOCMS_BACKUP_API_TOKEN,
-    };
-});
+const DATOCMS_BACKUP_API_TOKEN = 'some-fake-api-token';
 
 describe('client', () => {
+    beforeEach(() => {
+        process.env = {
+            DATOCMS_BACKUP_API_TOKEN,
+        };
+    });
+
     it('throws a misconfig error when the DATOCMS_BACKUP_API_TOKEN env variable is missing', (): void => {
         process.env = {};
 

--- a/src/dato.spec.ts
+++ b/src/dato.spec.ts
@@ -9,6 +9,7 @@ jest.mock('datocms-client', () => ({
 
 describe('client', () => {
     const DATOCMS_BACKUP_API_TOKEN = 'some-fake-api-token';
+    const DATOCMS_BACKUP_ASSETS_PROXY = 'some-fake-assets.proxy/content-assets';
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -103,5 +104,28 @@ describe('client', () => {
 
         expect(dataDump).toEqual(DatoFake.dataDump);
         expect(DatoFake.siteClient.items.all).toHaveBeenCalledWith({}, { allPages: true });
+    });
+
+    it('can get all asset URIs', async () => {
+        const client: Dato = createClient();
+
+        const assetURIs = await client.assetURIs();
+
+        expect(assetURIs).toContainEqual(
+            expect.stringContaining(`https://${DatoFake.imgixHost}/`),
+        );
+        expect(DatoFake.siteClient.uploads.all).toHaveBeenCalledWith({}, { allPages: true });
+    });
+
+    it('can get all asset URIs using a custom proxy domain', async () => {
+        process.env.DATOCMS_BACKUP_ASSETS_PROXY = DATOCMS_BACKUP_ASSETS_PROXY;
+        const client: Dato = createClient();
+
+        const assetURIs = await client.assetURIs();
+
+        expect(assetURIs).toContainEqual(
+            expect.stringContaining(`https://${DATOCMS_BACKUP_ASSETS_PROXY}/`),
+        );
+        expect(DatoFake.siteClient.uploads.all).toHaveBeenCalledWith({}, { allPages: true });
     });
 });

--- a/src/dato.spec.ts
+++ b/src/dato.spec.ts
@@ -1,5 +1,5 @@
 import { SiteClient } from 'datocms-client';
-import { CannotInitialiseDatoClient } from './errors/misconfigurationErrors';
+import { CannotCreateDatoClient } from './errors/misconfigurationErrors';
 import { createClient, Dato, Environment } from './dato';
 import { siteClient, fakePrimaryEnvironment, fakeBackup, fakeSandboxEnvironment } from './dato.fake';
 
@@ -23,8 +23,8 @@ describe('client', () => {
         try {
             createClient();
         } catch (error) {
-            expect(error).toBeInstanceOf(CannotInitialiseDatoClient);
-            expect(error).toEqual(CannotInitialiseDatoClient.missingApiToken());
+            expect(error).toBeInstanceOf(CannotCreateDatoClient);
+            expect(error).toEqual(CannotCreateDatoClient.missingApiToken());
         }
     });
 

--- a/src/dato.ts
+++ b/src/dato.ts
@@ -1,5 +1,5 @@
 import { SiteClient } from 'datocms-client';
-import { CannotInitialiseDatoClient } from './errors/misconfigurationErrors';
+import { CannotCreateDatoClient } from './errors/misconfigurationErrors';
 
 export type Environment = {
     readonly id: string
@@ -32,7 +32,7 @@ export function createClient(): Dato {
             return apiToken;
         }
 
-        throw CannotInitialiseDatoClient.missingApiToken();
+        throw CannotCreateDatoClient.missingApiToken();
     }
 
     return {

--- a/src/errors/handler.spec.ts
+++ b/src/errors/handler.spec.ts
@@ -18,7 +18,7 @@ describe('error handler', () => {
         const message = 'Whoops...';
 
         await handle(() => {
-            throw new RuntimeError(message);
+            throw new RuntimeError(message, new Error);
         }, output);
 
         expect(output.error).toHaveBeenCalledWith(message);

--- a/src/errors/handler.ts
+++ b/src/errors/handler.ts
@@ -13,11 +13,16 @@ export async function handle(process: Function, output: Output): Promise<void> {
         }
 
         if (error instanceof RuntimeError) {
-            output.error(error.message);
+            handleRuntimeError(error);
 
             return;
         }
 
         throw error;
+    }
+
+    function handleRuntimeError(error: RuntimeError): void {
+        output.debug(error.originalError);
+        output.error(error.message);
     }
 }

--- a/src/errors/misconfigurationErrors.ts
+++ b/src/errors/misconfigurationErrors.ts
@@ -11,6 +11,20 @@ export class CannotCreateDatoClient extends MisconfigurationError {
     }
 }
 
+export class CannotCreateS3Storage extends MisconfigurationError {
+    static missingAccessKeyId(): CannotCreateS3Storage {
+        return new CannotCreateS3Storage(
+            'To use the S3 storage, please provide a DATOCMS_BACKUP_AWS_ACCESS_KEY_ID environment variable.',
+        );
+    }
+
+    static missingAccessKeySecret(): CannotCreateS3Storage {
+        return new CannotCreateS3Storage(
+            'To use the S3 storage, please provide a DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET environment variable.',
+        );
+    }
+}
+
 export class FailedToStartCleanup extends MisconfigurationError {
     static argumentAgeIsInvalid(age: string): FailedToStartCleanup {
         return new FailedToStartCleanup(

--- a/src/errors/misconfigurationErrors.ts
+++ b/src/errors/misconfigurationErrors.ts
@@ -2,9 +2,9 @@ export class MisconfigurationError extends Error {
     //
 }
 
-export class CannotInitialiseDatoClient extends MisconfigurationError {
-    static missingApiToken(): CannotInitialiseDatoClient {
-        return new CannotInitialiseDatoClient(
+export class CannotCreateDatoClient extends MisconfigurationError {
+    static missingApiToken(): CannotCreateDatoClient {
+        return new CannotCreateDatoClient(
             'Please make sure to provide a valid DatoCMS API token by setting ' +
             'a DATOCMS_BACKUP_API_TOKEN environment variable.',
         );

--- a/src/errors/runtimeErrors.ts
+++ b/src/errors/runtimeErrors.ts
@@ -1,31 +1,45 @@
 import { BackupEnvironment, BackupEnvironmentId } from '../dato';
 
 export class RuntimeError extends Error {
-    //
+    constructor(message: string, public originalError: Error) {
+        super(message);
+    }
 }
 
 export class BackupFailed extends RuntimeError {
-    static datoApiRespondedWithAnErrorWhileResolvingPrimaryEnvironment(): BackupFailed {
+    static datoApiRespondedWithAnErrorWhileResolvingPrimaryEnvironment(originalError: Error): BackupFailed {
         return new BackupFailed(
             `Backup failed due to an error response from the DatoCMS API while resolving the primary environment.`,
+            originalError,
         );
     }
 
-    static datoApiRespondedWithAnErrorWhileCreatingBackup(backupId: BackupEnvironmentId): BackupFailed {
-        return new BackupFailed(`Backup "${backupId}" failed due to an error response from the DatoCMS API.`);
+    static datoApiRespondedWithAnErrorWhileCreatingBackup(
+        backupId: BackupEnvironmentId,
+        originalError: Error
+    ): BackupFailed {
+        return new BackupFailed(
+            `Backup "${backupId}" failed due to an error response from the DatoCMS API.`,
+            originalError,
+        );
     }
 }
 
 export class CleanupFailed extends RuntimeError {
-    static datoApiReturnedWithAnErrorWhileGettingBackupEnvironments(): CleanupFailed {
+    static datoApiReturnedWithAnErrorWhileGettingBackupEnvironments(originalError: Error): CleanupFailed {
         return new CleanupFailed(
             `Cleanup failed due to an error response from the DatoCMS API while getting backup environments.`,
+            originalError,
         );
     }
 
-    static datoApiReturnedWithAnErrorWhileDeletingBackup(backup: BackupEnvironment): CleanupFailed {
+    static datoApiReturnedWithAnErrorWhileDeletingBackup(
+        backup: BackupEnvironment,
+        originalError: Error
+    ): CleanupFailed {
         return new CleanupFailed(
             `Cleanup failed due to an error response from the DatoCMS API while deleting backup '${backup.id}'.`,
+            originalError,
         );
     }
 }

--- a/src/errors/runtimeErrors.ts
+++ b/src/errors/runtimeErrors.ts
@@ -43,3 +43,19 @@ export class CleanupFailed extends RuntimeError {
         );
     }
 }
+
+export class DumpFailed extends RuntimeError {
+    static datoApiRespondedWithAnErrorWhileGettingDataDump(originalError: Error): DumpFailed {
+        return new DumpFailed(
+            `Dump failed due to an error response from the DatoCMS API while getting the data dump.`,
+            originalError,
+        );
+    }
+
+    static s3ApiRespondedWithAnErrorWhileUploadingData(originalError: Error): DumpFailed {
+        return new DumpFailed(
+            `Dump failed due to an error response from the AWS S3 API while uploading data.`,
+            originalError,
+        );
+    }
+}

--- a/src/errors/runtimeErrors.ts
+++ b/src/errors/runtimeErrors.ts
@@ -52,9 +52,23 @@ export class DumpFailed extends RuntimeError {
         );
     }
 
-    static s3ApiRespondedWithAnErrorWhileUploadingData(originalError: Error): DumpFailed {
+    static storageApiRespondedWithAnErrorWhileUploadingData(originalError: Error): DumpFailed {
         return new DumpFailed(
-            `Dump failed due to an error response from the AWS S3 API while uploading data.`,
+            `Dump failed due to an error response from the storage API while uploading data.`,
+            originalError,
+        );
+    }
+
+    static errorWhileDownloadingAsset(assetURI: string, originalError: Error): DumpFailed {
+        return new DumpFailed(
+            `Dump failed due to an error while downloading asset "${assetURI}".`,
+            originalError,
+        );
+    }
+
+    static errorWhileUploadingAsset(assetPath: string, originalError: Error): DumpFailed {
+        return new DumpFailed(
+            `Dump failed due to an error while uploading asset "${assetPath}".`,
             originalError,
         );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,14 @@ import { config } from 'dotenv';
 import { Kernel, createKernel } from './kernel';
 import * as Create from './commands/create';
 import * as Cleanup from './commands/cleanup';
+import * as Dump from './commands/dump';
 
 config();
 
 const kernel: Kernel = createKernel(
     Create,
     Cleanup,
+    Dump,
 );
 
 kernel.boot();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@ import * as Cleanup from './commands/cleanup';
 config();
 
 const kernel: Kernel = createKernel(
-    Create.COMMAND,
-    Cleanup.COMMAND,
+    Create,
+    Cleanup,
 );
 
 kernel.boot();

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -49,7 +49,14 @@ export function createKernel(...commands: Command[]): Kernel {
             flags = `${flags} <value>`;
         }
 
-        cmd.option(flags, option.description, option.defaultValue || undefined);
+        const opt = cmd.createOption(flags, option.description)
+            .default(option.defaultValue || undefined);
+
+        if (option.hasOwnProperty('choices')) {
+            opt.choices(option.choices);
+        }
+
+        cmd.addOption(opt);
     }
 
     function mapInputToCommandHandler(cmd: Commander.Command, command: Command, ...input: any[]): Promise<void> {

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -45,6 +45,10 @@ export function createKernel(...commands: Command[]): Kernel {
             flags = `-${option.shortFlag}, ${flags}`;
         }
 
+        if (option.hasOwnProperty('defaultValue')) {
+            flags = `${flags} <value>`;
+        }
+
         cmd.option(flags, option.description, option.defaultValue || undefined);
     }
 

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -14,7 +14,7 @@ export function createKernel(...commands: Command[]): Kernel {
 
     function registerCommand(command: Command, cli: Commander.Command): void {
         const cmd = cli.command(command.name);
-        const argumentDefinitions = command.arguments ?? [];
+        const argumentDefinitions = command.args ?? [];
         const optionDefinitions = command.options ?? [];
         const subCommandDefinitions = command.subCommands ?? [];
 
@@ -53,7 +53,7 @@ export function createKernel(...commands: Command[]): Kernel {
     }
 
     function mapInputToCommandHandler(cmd: Commander.Command, command: Command, ...input: any[]): Promise<void> {
-        const argumentDefinitions = command.arguments ?? [];
+        const argumentDefinitions = command.args ?? [];
         const args = argumentDefinitions.reduce((
             args: Arguments,
             arg: ArgumentDefinition,

--- a/src/output.fake.ts
+++ b/src/output.fake.ts
@@ -15,6 +15,7 @@ export const output: Output = {
 
     debug: jest.fn((data: any): void => {}),
     error: jest.fn((message: string): void => {}),
+    warn: jest.fn((message: string): void => {}),
     help: jest.fn((): void => {}),
 
     line(message: string, icon: string | undefined): void {},

--- a/src/output.fake.ts
+++ b/src/output.fake.ts
@@ -15,7 +15,6 @@ export const output: Output = {
 
     debug: jest.fn((data: any): void => {}),
     error: jest.fn((message: string): void => {}),
-    warn: jest.fn((message: string): void => {}),
     help: jest.fn((): void => {}),
 
     line(message: string, icon: string | undefined): void {},

--- a/src/output.spec.ts
+++ b/src/output.spec.ts
@@ -44,15 +44,6 @@ describe('output', () => {
         await expect(outputProcess).toExitWithCode(1);
     });
 
-    it('can write a warning message to stderr', async () => {
-        const message = 'Something went wrong...';
-
-        const outputProcess = () => output.warn(message);
-
-        await expect(outputProcess).toWriteToStdErr(`\x1b[33m⚠️ ${message}\x1b[0m`);
-        await expect(outputProcess).toExitWithCode(0);
-    });
-
     it('does not write debug messages to stdout when debugging is not explicitly enabled', async () => {
         const message = 'Some debugging info...';
 

--- a/src/output.spec.ts
+++ b/src/output.spec.ts
@@ -44,6 +44,15 @@ describe('output', () => {
         await expect(outputProcess).toExitWithCode(1);
     });
 
+    it('can write a warning message to stderr', async () => {
+        const message = 'Something went wrong...';
+
+        const outputProcess = () => output.warn(message);
+
+        await expect(outputProcess).toWriteToStdErr(`\x1b[33m⚠️ ${message}\x1b[0m`);
+        await expect(outputProcess).toExitWithCode(0);
+    });
+
     it('does not write debug messages to stdout when debugging is not explicitly enabled', async () => {
         const message = 'Some debugging info...';
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -6,13 +6,13 @@ const FG_RED = '\x1b[31m';
 const RESET = '\x1b[0m';
 
 export type Output = {
-    misconfig: (message: string) => void
-    line: (message: string, icon?: string) => void
-    confirm: (question: string) => Promise<boolean>
-    completed: (message: string) => void
-    error: (message: string) => void
-    debug: (...data: any[]) => void
-    help: () => void
+    misconfig(message: string): void
+    line(message: string, icon?: string): void
+    confirm(question: string): Promise<boolean>
+    completed(message: string): void
+    error(message: string): void
+    debug(...data: any[]): void
+    help(): void
 }
 
 export type OutputOptions = {

--- a/src/output.ts
+++ b/src/output.ts
@@ -3,7 +3,6 @@ import { prompt } from 'inquirer';
 const FG_GREEN = '\x1b[32m';
 const FG_MAGENTA = '\x1b[35m';
 const FG_RED = '\x1b[31m';
-const FG_YELLOW = '\x1b[33m';
 const RESET = '\x1b[0m';
 
 export type Output = {
@@ -12,7 +11,6 @@ export type Output = {
     confirm(question: string): Promise<boolean>
     completed(message: string): void
     error(message: string): void
-    warn(message: string): void
     debug(...data: any[]): void
     help(): void
 }
@@ -56,10 +54,6 @@ export function createOutput(options: OutputOptions): Output {
         error(message: string): void {
             console.error(FG_RED + `🧨 ${message}` + RESET);
             process.exit(1);
-        },
-
-        warn(message: string): void {
-            console.warn(FG_YELLOW + `⚠️ ${message}` + RESET);
         },
 
         debug(...data: any[]): void {

--- a/src/output.ts
+++ b/src/output.ts
@@ -3,6 +3,7 @@ import { prompt } from 'inquirer';
 const FG_GREEN = '\x1b[32m';
 const FG_MAGENTA = '\x1b[35m';
 const FG_RED = '\x1b[31m';
+const FG_YELLOW = '\x1b[33m';
 const RESET = '\x1b[0m';
 
 export type Output = {
@@ -11,6 +12,7 @@ export type Output = {
     confirm(question: string): Promise<boolean>
     completed(message: string): void
     error(message: string): void
+    warn(message: string): void
     debug(...data: any[]): void
     help(): void
 }
@@ -54,6 +56,10 @@ export function createOutput(options: OutputOptions): Output {
         error(message: string): void {
             console.error(FG_RED + `🧨 ${message}` + RESET);
             process.exit(1);
+        },
+
+        warn(message: string): void {
+            console.warn(FG_YELLOW + `⚠️ ${message}` + RESET);
         },
 
         debug(...data: any[]): void {

--- a/src/storage.fake.ts
+++ b/src/storage.fake.ts
@@ -1,0 +1,26 @@
+import { Storage } from './storage';
+
+export let errors: {
+    [name: string]: Error | undefined
+} = {};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    errors = {
+        upload: undefined,
+    };
+});
+
+export function fakeErrorWhileUploadingToStorage(): void {
+    errors.dataDump = new Error('Faked an error while uploading to storage.');
+}
+
+export const storage: Storage = {
+    upload: jest.fn(async (path: string, content: string): Promise<void> => {
+        if (errors.upload) {
+            throw errors.upload;
+        }
+
+        return Promise.resolve();
+    }),
+}

--- a/src/storage.fake.ts
+++ b/src/storage.fake.ts
@@ -1,17 +1,24 @@
-import { Storage } from './storage';
+import { Driver, Storage } from './storage';
 
+export let usedDriver: Driver = undefined;
 export let errors: {
     [name: string]: Error | undefined
 } = {};
 
-beforeEach(() => {
-    jest.clearAllMocks();
+export function reset(): void {
+    usedDriver = undefined;
     errors = {
         upload: undefined,
     };
-});
+}
 
-export function fakeErrorWhileUploadingToStorage(): void {
+export function createWithDriver(driver: Driver): Storage {
+    usedDriver = driver;
+
+    return storage;
+}
+
+export function throwErrorWhileUploadingToStorage(): void {
     errors.dataDump = new Error('Faked an error while uploading to storage.');
 }
 
@@ -21,6 +28,10 @@ export const storage: Storage = {
             throw errors.upload;
         }
 
+        return Promise.resolve();
+    }),
+
+    uploadFromUri: jest.fn(async (path: string, uri: string): Promise<void> => {
         return Promise.resolve();
     }),
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,3 +1,5 @@
+import { pipeline, PipelineDestination, PipelineSource } from 'stream';
+import { promisify } from 'util';
 import * as S3 from './storage/s3';
 
 export enum Driver {
@@ -5,7 +7,12 @@ export enum Driver {
 }
 
 export type Storage = {
-    upload: (path: string, content: string) => Promise<void>
+    upload(path: string, content: string): Promise<void>
+    uploadFromUri(path: string, uri: string): Promise<void>
+}
+
+export function finished(src: PipelineSource<any>, dest: PipelineDestination<any, any>): Promise<void> {
+    return promisify(pipeline)(src, dest);
 }
 
 export function createStorage(driver: Driver): Storage {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,15 @@
+import * as S3 from './storage/s3';
+
+export enum Driver {
+    S3 = 's3'
+}
+
+export type Storage = {
+    upload: (path: string, content: string) => Promise<void>
+}
+
+export function createStorage(driver: Driver): Storage {
+    return {
+        [Driver.S3]: S3.createStorage,
+    }[driver]();
+}

--- a/src/storage/s3.spec.ts
+++ b/src/storage/s3.spec.ts
@@ -1,0 +1,59 @@
+import { Storage } from '../storage';
+import { S3 } from '../aws.fake';
+import { createStorage } from './s3';
+import { CannotCreateS3Storage } from '../errors/misconfigurationErrors';
+
+const DATOCMS_BACKUP_AWS_ACCESS_KEY_ID = 'some-fake-access-key-id';
+const DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET = 'some-fake-access-key-secret';
+
+jest.mock('aws-sdk', () => ({
+    S3: jest.fn(() => S3),
+}));
+
+describe('s3 storage', () => {
+    beforeEach(() => {
+        process.env = {
+            DATOCMS_BACKUP_AWS_ACCESS_KEY_ID,
+            DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET,
+        };
+    });
+
+    it('fails to create when the DATOCMS_BACKUP_AWS_ACCESS_KEY_ID env var is missing', async () => {
+        process.env = {
+            DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET,
+        };
+
+        try {
+            createStorage();
+        } catch (error) {
+            expect(error).toBeInstanceOf(CannotCreateS3Storage);
+        }
+    });
+
+    it('fails to create when the DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET env var is missing', async () => {
+        process.env = {
+            DATOCMS_BACKUP_AWS_ACCESS_KEY_ID,
+        };
+
+        try {
+            createStorage();
+        } catch (error) {
+            expect(error).toBeInstanceOf(CannotCreateS3Storage);
+        }
+    });
+
+    it('can upload to S3', async () => {
+        const storage: Storage = createStorage();
+        const path: string = 'bucket/path/to/file.json';
+        const content: string = 'Some content';
+
+        await storage.upload(path, content);
+
+        expect(S3.upload).toHaveBeenCalledTimes(1);
+        expect(S3.upload).toHaveBeenCalledWith({
+            Bucket: 'bucket',
+            Key: 'path/to/file.json',
+            Body: content,
+        });
+    });
+});

--- a/src/storage/s3.spec.ts
+++ b/src/storage/s3.spec.ts
@@ -1,5 +1,5 @@
+import * as AwsFake from '../aws.fake';
 import { Storage } from '../storage';
-import { S3 } from '../aws.fake';
 import { createStorage } from './s3';
 import { CannotCreateS3Storage } from '../errors/misconfigurationErrors';
 
@@ -7,11 +7,12 @@ const DATOCMS_BACKUP_AWS_ACCESS_KEY_ID = 'some-fake-access-key-id';
 const DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET = 'some-fake-access-key-secret';
 
 jest.mock('aws-sdk', () => ({
-    S3: jest.fn(() => S3),
+    S3: jest.fn(() => AwsFake.S3),
 }));
 
 describe('s3 storage', () => {
     beforeEach(() => {
+        jest.clearAllMocks();
         process.env = {
             DATOCMS_BACKUP_AWS_ACCESS_KEY_ID,
             DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET,
@@ -49,8 +50,8 @@ describe('s3 storage', () => {
 
         await storage.upload(path, content);
 
-        expect(S3.upload).toHaveBeenCalledTimes(1);
-        expect(S3.upload).toHaveBeenCalledWith({
+        expect(AwsFake.S3.upload).toHaveBeenCalledTimes(1);
+        expect(AwsFake.S3.upload).toHaveBeenCalledWith({
             Bucket: 'bucket',
             Key: 'path/to/file.json',
             Body: content,

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -1,5 +1,7 @@
 import { S3 } from 'aws-sdk';
-import { Storage } from '../storage';
+import got from 'got';
+import { PassThrough } from 'stream';
+import { Storage, finished } from '../storage';
 import { CannotCreateS3Storage } from '../errors/misconfigurationErrors';
 
 export function createStorage(): Storage {
@@ -23,16 +25,39 @@ export function createStorage(): Storage {
         });
     }
 
+    function resolveBucketAndKeyFromPath(path: string): { Bucket: string, Key: string } {
+        const key = path.split('/');
+        const bucket = key.shift();
+
+        return {
+            Bucket: bucket,
+            Key: key.join('/'),
+        };
+    }
+
     return {
         async upload(path: string, content: string): Promise<void> {
-            const key = path.split('/');
-            const bucket = key.shift();
+            const { Bucket, Key } = resolveBucketAndKeyFromPath(path);
 
             await s3.upload({
-                Bucket: bucket,
-                Key: key.join('/'),
+                Bucket,
+                Key,
                 Body: content,
             }).promise();
+        },
+
+        async uploadFromUri(path: string, uri: string): Promise<void> {
+            const { Bucket, Key } = resolveBucketAndKeyFromPath(path);
+            const passThrough = new PassThrough();
+            const file = got.stream(uri);
+
+            s3.upload({
+                Bucket,
+                Key,
+                Body: passThrough,
+            }).promise();
+
+            return await finished(file, passThrough);
         },
     };
 }

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -1,0 +1,38 @@
+import { S3 } from 'aws-sdk';
+import { Storage } from '../storage';
+import { CannotCreateS3Storage } from '../errors/misconfigurationErrors';
+
+export function createStorage(): Storage {
+    const s3: S3 = createS3Client();
+
+    function createS3Client(): S3 {
+        const accessKeyId = process.env.DATOCMS_BACKUP_AWS_ACCESS_KEY_ID;
+        const secretAccessKey = process.env.DATOCMS_BACKUP_AWS_ACCESS_KEY_SECRET;
+
+        if (! accessKeyId) {
+            throw CannotCreateS3Storage.missingAccessKeyId();
+        }
+
+        if (! secretAccessKey) {
+            throw CannotCreateS3Storage.missingAccessKeyId();
+        }
+
+        return new S3({
+            accessKeyId,
+            secretAccessKey,
+        });
+    }
+
+    return {
+        async upload(path: string, content: string): Promise<void> {
+            const key = path.split('/');
+            const bucket = key.shift();
+
+            await s3.upload({
+                Bucket: bucket,
+                Key: key.join('/'),
+                Body: content,
+            }).promise();
+        },
+    };
+}


### PR DESCRIPTION
This PR adds the ability to upload a data dump to a storage service outside of DatoCMS. This first implementation adds support for AWS S3.

### CLI spec:

```
datocms-backup dump <storage> <path>
```